### PR TITLE
getOriginalComponent returns component ref now

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,11 @@ function subscribe(store, Component, mapping = null) {
     }
 
     getOriginalComponent() {
-      return this.originalComponent;
+      return Component;
+    }
+    
+    getOriginalComponentRef() {
+      return this.originalComponent; 
     }
 
     updateToystoreMapping(toystoreMapping) {

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ function subscribe(store, Component, mapping = null) {
     }
 
     getOriginalComponent() {
-      return Component;
+      return this.originalComponent;
     }
 
     updateToystoreMapping(toystoreMapping) {
@@ -105,7 +105,7 @@ function subscribe(store, Component, mapping = null) {
     }
 
     render() {
-      let props = Object.assign({}, this.props, this.state.toystoreMapping);
+      let props = Object.assign({}, this.props, this.state.toystoreMapping, {ref: node => this.originalComponent = node});
 
       return React.createElement(Component, props, this.props.children);
     }


### PR DESCRIPTION
getOriginalComponent was returning the class of the wrapped Component. By returning a ref of the rendered wrapped Component users will have access to the Component's methods if need be.